### PR TITLE
Migrate Google Gemini to OpenRouter to bypass API quota limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ Tip Genius leverages LLMs to generate match predictions by analyzing odds data a
 
 So far, the following LLM models have been successfully tested with Tip Genius:
 
-- **Mistral Medium 3.1** (Free API available)
-- **Google Gemini 2.5 Flash Lite** (Free API available)
-- **DeepSeek Chat V3.2**
-- **OpenAI GPT-5 Mini**
+- **Mistral Medium 3.1** (Free API, via Mistral AI)
+- **OpenAI GPT-5 Mini** (via OpenAI)
+- **DeepSeek Chat V3.2** (via DeepSeek)
 - **Meta Llama 4 Maverick** (via DeepInfra)
 - **Microsoft Phi-4** (via DeepInfra)
+- **Google Gemini 2.5 Flash Lite** (via OpenRouter)
 - **xAI Grok 4.1 Fast** (via OpenRouter)
 
 Issues with some LLMs:

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -3,8 +3,13 @@
 
 // LLM provider configuration with PNG logos
 const LLM_PROVIDERS = [
+  // {
+  //   value: 'Google-Gemini-Flash-Lite',
+  //   label: 'Gemini 2.5 Flash Lite',
+  //   logo: `/images/llm-logos/Google.png`,
+  // },
   {
-    value: 'Google-Gemini-Flash-Lite',
+    value: 'OpenRouter-Gemini-Flash-Lite',
     label: 'Gemini 2.5 Flash Lite',
     logo: `/images/llm-logos/Google.png`,
   },

--- a/src/tip_genius/cfg/llm_config.yaml
+++ b/src/tip_genius/cfg/llm_config.yaml
@@ -31,16 +31,16 @@ deepseek-chat:
     response_format:
       type: json_object
 
-google-gemini-flash-lite:
-  api_rate_limit: 8 # requests per minute for free tier
-  api_key_env_name: GOOGLE_API_KEY
-  base_url: https://generativelanguage.googleapis.com/v1beta
-  operation: generateContent # alternative: streamGenerateContent for stream
-  model: gemini-2.5-flash-lite
-  kwargs:
-    temperature: 0.0
-    maxOutputTokens: 8192
-    response_mime_type: 'application/json'
+# google-gemini-flash-lite:
+#   api_rate_limit: 8 # requests per minute for free tier
+#   api_key_env_name: GOOGLE_API_KEY
+#   base_url: https://generativelanguage.googleapis.com/v1beta
+#   operation: generateContent # alternative: streamGenerateContent for stream
+#   model: gemini-2.5-flash-lite
+#   kwargs:
+#     temperature: 0.0
+#     maxOutputTokens: 8192
+#     response_mime_type: 'application/json'
 
 microsoft-phi-medium:
   api_key_env_name: DEEPINFRA_API_KEY
@@ -79,15 +79,32 @@ openai-gpt-mini:
     response_format:
       type: json_object
 
-anthropic-claude-haiku:
-  api_key_env_name: ANTHROPIC_API_KEY
-  base_url: https://api.anthropic.com/v1
-  operation: messages
-  model: claude-3-5-haiku-20241022
+# anthropic-claude-haiku:
+#   api_key_env_name: ANTHROPIC_API_KEY
+#   base_url: https://api.anthropic.com/v1
+#   operation: messages
+#   model: claude-3-5-haiku-20241022
+#   kwargs:
+#     temperature: 0.0
+#     stream: false
+#     max_tokens: 8192
+
+openrouter-gemini-flash-lite:
+  api_key_env_name: OPENROUTER_API_KEY
+  base_url: https://openrouter.ai/api/v1
+  operation: chat/completions
+  model: google/gemini-2.5-flash-lite
   kwargs:
     temperature: 0.0
     stream: false
     max_tokens: 8192
+    reasoning:
+      effort: medium # 'low', 'medium', 'high', 'xhigh'
+    response_format:
+      type: json_object
+  optional_headers:
+    HTTP-Referer: 'https://tip-genius.vercel.app'
+    X-Title: 'Tip Genius'
 
 openrouter-grok:
   api_key_env_name: OPENROUTER_API_KEY
@@ -98,6 +115,8 @@ openrouter-grok:
     temperature: 0.0
     stream: false
     max_tokens: 8192
+    reasoning:
+      effort: medium # 'low', 'medium', 'high', 'xhigh'
     response_format:
       type: json_object
   optional_headers:

--- a/src/tip_genius/cfg/tip_genius_config.yaml
+++ b/src/tip_genius/cfg/tip_genius_config.yaml
@@ -9,12 +9,13 @@ sports_list:
 
 # List of LLM Providers to use for Tips generation
 llm_provider_options:
-  - Google-Gemini-Flash-Lite
+  # - Google-Gemini-Flash-Lite # API Rate Limits
   - Deepseek-Chat
   - Mistral-Medium
   - Meta-Llama-Mid
   - Microsoft-Phi-Medium
   - OpenAI-GPT-Mini
+  - OpenRouter-Gemini-Flash-Lite
   - OpenRouter-Grok
   # - Anthropic-Claude-Haiku # No Json Mode: sometimes has issues with JSON output
 

--- a/src/tip_genius/lib/llm_manager.py
+++ b/src/tip_genius/lib/llm_manager.py
@@ -197,7 +197,7 @@ class LLMManager:
                 "stream": False,
                 **llm_kwargs,
             }
-        # For Google Gemini, we need to structure the request differently
+        # For Google Gemini API, we need to structure the request differently
         elif self.provider.startswith("google"):
             url = f"{self.base_url}/models/{self.model}:{self.operation}"
             headers["x-goog-api-key"] = self.api_key


### PR DESCRIPTION
## Summary
- Migrate Google Gemini 2.5 Flash Lite from direct Google API to OpenRouter
- Add reasoning effort configuration (medium) for both OpenRouter providers
- Bypass Google API free tier quota restrictions
- Comment out direct Google API configuration for future reference

## Changes
- **LLM Configuration**: Add `openrouter-gemini-flash-lite` with reasoning support
- **Frontend**: Update provider to use OpenRouter-based Gemini
- **Main Config**: Switch default from direct Google API to OpenRouter
- **Reasoning**: Add `reasoning.effort: medium` to both Gemini and Grok configurations
- **README**: Clarify model sources and update provider list