### PR TITLE
Update GPT-5 Mini to use OpenRouter configuration

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -60,7 +60,7 @@
                             </svg>
                         </button>
                         <!-- Dropdown menu -->
-                        <div id="dropdownMenu" class="hidden absolute right-0 mt-2 w-60 sm:w-72 bg-gray-50 dark:bg-gray-700 border border-slate-300 dark:border-slate-500 rounded-lg shadow-lg z-50">
+                        <div id="dropdownMenu" class="hidden absolute right-0 mt-2 w-72 sm:w-72 bg-gray-50 dark:bg-gray-700 border border-slate-300 dark:border-slate-500 rounded-lg shadow-lg z-50">
                             <div class="p-6">
                                 <h3 class="text-base sm:text-lg font-bold text-gray-800 dark:text-gray-200 mb-3">Large Language Model</h3>
                                 <div id="llm-providers" class="space-y-3">

--- a/public/index.html
+++ b/public/index.html
@@ -60,7 +60,7 @@
                             </svg>
                         </button>
                         <!-- Dropdown menu -->
-                        <div id="dropdownMenu" class="hidden absolute right-0 mt-2 w-72 sm:w-72 bg-gray-50 dark:bg-gray-700 border border-slate-300 dark:border-slate-500 rounded-lg shadow-lg z-50">
+                        <div id="dropdownMenu" class="hidden absolute right-0 mt-2 w-72 bg-gray-50 dark:bg-gray-700 border border-slate-300 dark:border-slate-500 rounded-lg shadow-lg z-50">
                             <div class="p-6">
                                 <h3 class="text-base sm:text-lg font-bold text-gray-800 dark:text-gray-200 mb-3">Large Language Model</h3>
                                 <div id="llm-providers" class="space-y-3">

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -14,7 +14,7 @@ const LLM_PROVIDERS = [
     logo: `/images/llm-logos/Google.png`,
   },
   {
-    value: 'OpenAI-GPT-Mini',
+    value: 'OpenRouter-GPT-5-Mini',
     label: 'GPT-5 Mini',
     logo: `/images/llm-logos/OpenAI.png`,
   },

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -14,7 +14,7 @@ const LLM_PROVIDERS = [
     logo: `/images/llm-logos/Google.png`,
   },
   {
-    value: 'OpenRouter-GPT-5-Mini',
+    value: 'OpenRouter-GPT-Mini',
     label: 'GPT-5 Mini',
     logo: `/images/llm-logos/OpenAI.png`,
   },

--- a/src/tip_genius/cfg/llm_config.yaml
+++ b/src/tip_genius/cfg/llm_config.yaml
@@ -66,28 +66,35 @@ meta-llama-mid:
     response_format:
       type: json_object
 
-openai-gpt-mini:
-  api_key_env_name: OPENAI_API_KEY
-  base_url: https://api.openai.com/v1
+# openai-gpt-mini:
+#   api_key_env_name: OPENAI_API_KEY
+#   base_url: https://api.openai.com/v1
+#   operation: chat/completions
+#   model: gpt-5-mini
+#   kwargs:
+#     temperature: 1.0 # GPT 5 only supports temperature >= 1.0
+#     stream: false
+#     max_completion_tokens: 8192
+#     reasoning_effort: low # 'minimal', 'low', 'medium', 'high'
+#     response_format:
+#       type: json_object
+
+openrouter-gpt-5-mini:
+  api_key_env_name: OPENROUTER_API_KEY
+  base_url: https://openrouter.ai/api/v1
   operation: chat/completions
-  model: gpt-5-mini
+  model: openai/gpt-5-mini
   kwargs:
     temperature: 1.0 # GPT 5 only supports temperature >= 1.0
     stream: false
-    max_completion_tokens: 8192
-    reasoning_effort: low # 'minimal', 'low', 'medium', 'high'
+    max_tokens: 8192
+    reasoning:
+      effort: low # 'low', 'medium', 'high', 'xhigh'
     response_format:
       type: json_object
-
-# anthropic-claude-haiku:
-#   api_key_env_name: ANTHROPIC_API_KEY
-#   base_url: https://api.anthropic.com/v1
-#   operation: messages
-#   model: claude-3-5-haiku-20241022
-#   kwargs:
-#     temperature: 0.0
-#     stream: false
-#     max_tokens: 8192
+  optional_headers:
+    HTTP-Referer: 'https://tip-genius.vercel.app'
+    X-Title: 'Tip Genius'
 
 openrouter-gemini-flash-lite:
   api_key_env_name: OPENROUTER_API_KEY
@@ -122,3 +129,12 @@ openrouter-grok:
   optional_headers:
     HTTP-Referer: 'https://tip-genius.vercel.app'
     X-Title: 'Tip Genius'
+# anthropic-claude-haiku:
+#   api_key_env_name: ANTHROPIC_API_KEY
+#   base_url: https://api.anthropic.com/v1
+#   operation: messages
+#   model: claude-3-5-haiku-20241022
+#   kwargs:
+#     temperature: 0.0
+#     stream: false
+#     max_tokens: 8192

--- a/src/tip_genius/cfg/llm_config.yaml
+++ b/src/tip_genius/cfg/llm_config.yaml
@@ -79,7 +79,7 @@ meta-llama-mid:
 #     response_format:
 #       type: json_object
 
-openrouter-gpt-5-mini:
+openrouter-gpt-mini:
   api_key_env_name: OPENROUTER_API_KEY
   base_url: https://openrouter.ai/api/v1
   operation: chat/completions

--- a/src/tip_genius/cfg/tip_genius_config.yaml
+++ b/src/tip_genius/cfg/tip_genius_config.yaml
@@ -14,7 +14,7 @@ llm_provider_options:
   - Mistral-Medium
   - Meta-Llama-Mid
   - Microsoft-Phi-Medium
-  - OpenAI-GPT-Mini
+  - OpenRouter-GPT-5-Mini
   - OpenRouter-Gemini-Flash-Lite
   - OpenRouter-Grok
   # - Anthropic-Claude-Haiku # No Json Mode: sometimes has issues with JSON output

--- a/src/tip_genius/cfg/tip_genius_config.yaml
+++ b/src/tip_genius/cfg/tip_genius_config.yaml
@@ -14,7 +14,7 @@ llm_provider_options:
   - Mistral-Medium
   - Meta-Llama-Mid
   - Microsoft-Phi-Medium
-  - OpenRouter-GPT-5-Mini
+  - OpenRouter-GPT-Mini
   - OpenRouter-Gemini-Flash-Lite
   - OpenRouter-Grok
   # - Anthropic-Claude-Haiku # No Json Mode: sometimes has issues with JSON output


### PR DESCRIPTION
# Summary
- Switch GPT-5 Mini from the direct OpenAI API configuration to OpenRouter
- Minor Fix to LLM Picker width on Mobile

# Motivation
- Route GPT-5 Mini through the same OpenRouter-based serving path used by other hosted models

# Changes
- Add an `openrouter-gpt-5-mini` provider using `openai/gpt-5-mini` via `https://openrouter.ai/api/v1`
- Keep the previous direct `openai-gpt-mini` configuration commented out for future reuse
- Update the frontend provider selector to use `OpenRouter-GPT-5-Mini` for GPT-5 Mini

- ⚠️ Breaking Changes
- Stored selections or KV keys using `OpenAI-GPT-Mini` will not automatically map to `OpenRouter-GPT-5-Mini`
 