### PR TITLE
Fix code scanning and Dependabot findings

### DIFF
--- a/.github/workflows/match-predictions.yaml
+++ b/.github/workflows/match-predictions.yaml
@@ -9,6 +9,9 @@ on:
   # Allow manual triggers through GitHub UI for testing and ad-hoc updates
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   update-predictions:
     runs-on: ubuntu-latest

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "tip-genius",
-  "version": "1.0.0",
+  "version": "3.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tip-genius",
-      "version": "1.0.0",
-      "license": "ISC",
+      "version": "3.2.0",
+      "license": "SEE LICENSE FILE",
       "devDependencies": {
         "autoprefixer": "^10.5.0",
         "concurrently": "^9.2.1",
@@ -1141,9 +1141,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -36,5 +36,8 @@
     "concurrently": "^9.2.1",
     "postcss": "^8.5.3",
     "tailwindcss": "^3.4"
+  },
+  "overrides": {
+    "picomatch": "^2.3.2"
   }
 }

--- a/src/tip_genius/lib/api_data.py
+++ b/src/tip_genius/lib/api_data.py
@@ -12,6 +12,7 @@ import os
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Any
+from urllib.parse import parse_qsl
 
 import polars as pl
 import requests
@@ -147,31 +148,37 @@ class OddsAPI(BaseAPI):
             error_msg = f"Sport key not found in sports mapping: {sport_key}"
             raise KeyError(error_msg) from exc
 
-        # Construct the URL for the API request
-        url = f"{self.base_url}{sports_value}/{self.parameters}&apiKey={self.api_key}"
+        # Construct the URL and query parameters for the API request.
+        endpoint, _, query_string = self.parameters.partition("?")
+        url = f"{self.base_url}{sports_value}/{endpoint}"
+        request_params = dict(parse_qsl(query_string, keep_blank_values=True))
+        request_params["apiKey"] = self.api_key
 
         # Fetch data from the API
         logger.debug("Fetching odds data for sport: %s", sport_key)
-        response = requests.get(url, timeout=10)
+        response = requests.get(url, params=request_params, timeout=10)
 
         # Check if the response was successful
         if response.status_code != 200:
+            request_id = (
+                response.headers.get("x-request-id")
+                or response.headers.get("request-id")
+                or "unavailable"
+            )
             logger.error(
-                "Failed to fetch odds data: %s %s",
+                "Failed to fetch odds data for sport %s: status=%s request_id=%s",
+                sport_key,
                 response.status_code,
-                response.text,
+                request_id,
             )
             error_message = (
-                f"Failed to fetch odds data: {response.status_code} {response.text}"
+                f"Failed to fetch odds data for sport {sport_key}: "
+                f"HTTP {response.status_code} (request_id={request_id})"
             )
-            raise requests.exceptions.HTTPError(error_message)
+            raise requests.exceptions.HTTPError(error_message, response=response)
 
         api_result = response.json()
-        logger.info(
-            "Successfully fetched odds data for sport: %s | API credits remaining: %s",
-            sport_key,
-            response.headers.get("x-requests-remaining", "unknown"),
-        )
+        logger.info("Successfully fetched odds data for sport: %s", sport_key)
 
         return api_result
 


### PR DESCRIPTION
# Summary
- Address code scanning alerts in the prediction workflow and API client
- Resolve the Dependabot advisory for transitive `picomatch`

# Motivation
- Reduce security noise from automated alerts and align the repo with least-privilege and safer logging practices
- Keep the npm dependency tree on a patched `picomatch` release without changing the app’s Tailwind setup

# Changes
- API client
  - Removed logging of raw Odds API response bodies and quota headers
  - Switched request construction to use query params instead of embedding the API key in the URL string
  - Kept failures actionable by logging status and request ID only
- GitHub Actions
  - Added explicit workflow permissions with `contents: read`
- npm dependencies
  - Added an override to force `picomatch@^2.3.2`
  - Regenerated `package-lock.json` so the patched transitive dependency is resolved

# Testing
- `uv run ruff check src/tip_genius/lib/api_data.py`
- `uv run pyright src/tip_genius/lib/api_data.py`
- `npm ls picomatch`
- `npm audit --json`