### PR TITLE
Add DeepSeek-4-Flash Model and LLM Smoke Tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,18 @@ uv run pre-commit install --hook-type commit-msg
 # Run prediction workflow locally with debug logging
 cd src/tip_genius && DEBUG_MODE=TRUE uv run python tip_genius.py
 # Logs written to src/tip_genius/logs/ — load .env.local from repo root
+
+# Smoke tests (live LLM calls — costs real money, run on demand only)
+RUN_SMOKE=1 uv run pytest tests/smoke -m smoke -v
 ```
+
+## Smoke Tests
+
+`tests/smoke/test_tip_genius_workflow.py` invokes every active provider via
+`LLMManager.get_prediction()`. Gated by the `smoke` marker and `RUN_SMOKE=1`
+(deselected by default). Each run costs real API spend — never execute
+automatically. **Suggest running** after changes to `cfg/llm_config.yaml`,
+`cfg/tip_genius_config.yaml`, or `lib/llm_manager.py`.
 
 ## Generated Artifacts & Large Directories
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ So far, the following LLM models have been successfully tested with Tip Genius:
 
 - **Mistral Medium 3.1** (Free API, via Mistral AI)
 - **OpenAI GPT-OSS 120b** (free, via OpenRouter)
-- **DeepSeek Chat V3.2** (via DeepSeek)
+- **DeepSeek V4 Flash** (via DeepSeek)
 - **Meta Llama 4 Maverick** (via DeepInfra)
 - **Microsoft Phi-4** (via DeepInfra)
 - **Google Gemma 4** (free, via Google AI Studio)

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -25,7 +25,7 @@ const LLM_PROVIDERS = [
   },
   {
     value: 'Deepseek-Chat',
-    label: 'DeepSeek V3.2',
+    label: 'DeepSeek V4 Flash',
     logo: `/images/llm-logos/DeepSeek.png`,
   },
   {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,16 @@ dev = [
     "pre-commit>=4.3.0",
     "ruff>=0.8.0",
     "pyright>=1.1.390",
+    "pytest>=8.0.0",
 ]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+markers = [
+    "smoke: live smoke tests that hit external LLM APIs (incurs cost; gated by RUN_SMOKE=1)",
+]
+addopts = "-m 'not smoke'"
+pythonpath = ["src/tip_genius"]
 
 [tool.ruff]
 line-length = 88
@@ -86,8 +95,8 @@ line-ending = "auto"
 [tool.pyright]
 typeCheckingMode = "standard"
 pythonVersion = "3.12"
-include = ["src", "utils"]
-extraPaths = ["src"]
+include = ["src", "utils", "tests"]
+extraPaths = ["src", "src/tip_genius"]
 exclude = [
     "**/__pycache__",
     "**/.pytest_cache",

--- a/src/tip_genius/cfg/llm_config.yaml
+++ b/src/tip_genius/cfg/llm_config.yaml
@@ -23,11 +23,13 @@ deepseek-chat:
   api_key_env_name: DEEPSEEK_API_KEY
   base_url: https://api.deepseek.com
   operation: chat/completions
-  model: deepseek-chat
+  model: deepseek-v4-flash
   kwargs:
     temperature: 0.0
     stream: false
     max_tokens: 8192
+    thinking:
+      type: disabled
     response_format:
       type: json_object
 
@@ -106,8 +108,10 @@ google-gemma-medium:
     temperature: 0.0
     maxOutputTokens: 8192
     responseMimeType: 'application/json'
+    thinkingConfig:
+      thinkingLevel: minimal
     # thinkingConfig options for Gemma models:
-    # - omit entirely: full thinking (~259 thought tokens, default)
+    # - omit entirely: full thinking (default)
     # - thinkingConfig: {thinkingLevel: minimal}: near-zero thinking (~0 thought tokens)
     # - thinkingLevel: low/medium/high: NOT supported for Gemma (Gemini-only)
 

--- a/src/tip_genius/lib/api_data.py
+++ b/src/tip_genius/lib/api_data.py
@@ -21,7 +21,7 @@ import yaml
 # %% --------------------------------------------
 # * Config
 
-ODDS_CONFIG_FILE = Path("cfg") / "api_config.yaml"
+ODDS_CONFIG_FILE = Path(__file__).parents[1] / "cfg" / "api_config.yaml"
 
 # Set up logging
 logger = logging.getLogger(__name__)

--- a/src/tip_genius/lib/llm_manager.py
+++ b/src/tip_genius/lib/llm_manager.py
@@ -15,9 +15,10 @@ from typing import Any
 
 import requests
 import yaml
-from lib.llm_prompts import Prompt
 
-LLM_CONFIG_FILE = Path("cfg") / "llm_config.yaml"
+from .llm_prompts import Prompt
+
+LLM_CONFIG_FILE = Path(__file__).parents[1] / "cfg" / "llm_config.yaml"
 
 # Set up logging
 logger = logging.getLogger(__name__)

--- a/src/tip_genius/lib/storage_manager.py
+++ b/src/tip_genius/lib/storage_manager.py
@@ -82,7 +82,7 @@ class StorageManager:
         """
         try:
             # Load KV config
-            config_path = Path("cfg") / "vercel_config.yaml"
+            config_path = Path(__file__).parents[1] / "cfg" / "vercel_config.yaml"
             with config_path.open(encoding="utf-8") as f:
                 config = yaml.safe_load(f)["tip_genius"]
 

--- a/src/tip_genius/tip_genius.py
+++ b/src/tip_genius/tip_genius.py
@@ -884,7 +884,7 @@ if __name__ == "__main__":
         setattr(tip_genius, option, value)
 
     # Load Config
-    config_path = Path("cfg") / "tip_genius_config.yaml"
+    config_path = Path(__file__).parent / "cfg" / "tip_genius_config.yaml"
     with config_path.open(encoding="utf-8") as f:
         tip_genius_config = yaml.safe_load(f)
     # Execute Workflow

--- a/tests/smoke/test_tip_genius_workflow.py
+++ b/tests/smoke/test_tip_genius_workflow.py
@@ -1,0 +1,61 @@
+"""Live smoke tests for configured LLM providers.
+
+Sends a tiny JSON-mode-safe prompt to every provider listed in
+``tip_genius_config.yaml -> llm_provider_options`` and asserts that a
+non-empty response comes back. Validates real API keys, endpoints, and
+model identifiers end-to-end through the production ``LLMManager`` path.
+
+Gated by the ``smoke`` pytest marker (deselected by default) AND the
+``RUN_SMOKE=1`` environment variable, since each invocation costs money.
+
+Run with::
+
+    RUN_SMOKE=1 uv run pytest tests/smoke -m smoke -v
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+import yaml
+from dotenv import load_dotenv
+from lib.llm_manager import LLMManager
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TIP_GENIUS_CONFIG = REPO_ROOT / "src" / "tip_genius" / "cfg" / "tip_genius_config.yaml"
+
+# Minimal odds-style prompt aligned with the production system prompt.
+# Using a generic prompt would conflict with the system instruction and cause
+# reasoning models (e.g. GPT-OSS) to emit empty content.
+SMOKE_PROMPT = "Liverpool FC : 2.1, Manchester United : 2.0, draw : 1.9"
+
+
+def _active_providers() -> list[str]:
+    with TIP_GENIUS_CONFIG.open(encoding="utf-8") as f:
+        config = yaml.safe_load(f)
+    return list(config["llm_provider_options"])
+
+
+pytestmark = [
+    pytest.mark.smoke,
+    pytest.mark.skipif(
+        os.environ.get("RUN_SMOKE") != "1",
+        reason="Smoke tests incur API cost; set RUN_SMOKE=1 to enable.",
+    ),
+]
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _load_env() -> None:
+    load_dotenv(REPO_ROOT / ".env.local")
+
+
+@pytest.mark.parametrize("provider", _active_providers())
+def test_llm_provider_responds(provider: str) -> None:
+    """Each active provider returns a non-empty response to a trivial prompt."""
+    llm = LLMManager(provider=provider)
+    response = llm.get_prediction(SMOKE_PROMPT, timeout=60)
+    assert isinstance(response, str)
+    assert response.strip(), f"{provider} returned empty response"

--- a/uv.lock
+++ b/uv.lock
@@ -46,6 +46,15 @@ wheels = [
 ]
 
 [[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
 name = "distlib"
 version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -82,6 +91,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "nodeenv"
 version = "1.9.1"
 source = { registry = "https://pypi.org/simple" }
@@ -91,12 +109,30 @@ wheels = [
 ]
 
 [[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
 name = "platformdirs"
 version = "4.5.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cf/86/0248f086a84f01b37aaec0fa567b397df1a119f73c16f6c7a9aac73ea309/platformdirs-4.5.1.tar.gz", hash = "sha256:61d5cdcc6065745cdd94f0f878977f8de9437be93de97c1c12f853c9c0cdcbda", size = 21715, upload-time = "2025-12-05T13:52:58.638Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/28/3bfe2fa5a7b9c46fe7e13c97bda14c895fb10fa2ebf1d0abb90e0cea7ee1/platformdirs-4.5.1-py3-none-any.whl", hash = "sha256:d03afa3963c806a9bed9d5125c8f4cb2fdaf74a55ab60e5d59b3fde758104d31", size = 18731, upload-time = "2025-12-05T13:52:56.823Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -142,6 +178,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
 name = "pyright"
 version = "1.1.407"
 source = { registry = "https://pypi.org/simple" }
@@ -152,6 +197,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a6/1b/0aa08ee42948b61745ac5b5b5ccaec4669e8884b53d31c8ec20b2fcd6b6f/pyright-1.1.407.tar.gz", hash = "sha256:099674dba5c10489832d4a4b2d302636152a9a42d317986c38474c76fe562262", size = 4122872, upload-time = "2025-10-24T23:17:15.145Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/93/b69052907d032b00c40cb656d21438ec00b3a471733de137a3f65a49a0a0/pyright-1.1.407-py3-none-any.whl", hash = "sha256:6dd419f54fcc13f03b52285796d65e639786373f433e243f8b94cf93a7444d21", size = 5997008, upload-time = "2025-10-24T23:17:13.159Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]
@@ -259,6 +320,7 @@ dependencies = [
 dev = [
     { name = "pre-commit" },
     { name = "pyright" },
+    { name = "pytest" },
     { name = "ruff" },
 ]
 
@@ -275,6 +337,7 @@ requires-dist = [
 dev = [
     { name = "pre-commit", specifier = ">=4.3.0" },
     { name = "pyright", specifier = ">=1.1.390" },
+    { name = "pytest", specifier = ">=8.0.0" },
     { name = "ruff", specifier = ">=0.8.0" },
 ]
 


### PR DESCRIPTION
# Summary
- Refresh the DeepSeek provider to target V4 Flash with disabled thinking.
- Add gated live smoke tests for configured LLM providers and make config loading resilient to working-directory changes.
- Update docs and type-check/test configuration to reflect the new workflow.

# Motivation
- Keep the DeepSeek integration aligned with the currently supported model and avoid relying on stale provider labels.
- Make the runtime and test entry points work consistently whether the app is launched from the repo root or `src/tip_genius`.
- Add a lightweight end-to-end check that validates the active LLM provider set against real API endpoints without running by default.

# Changes
- API / LLM configuration
  - Switched the DeepSeek provider from `deepseek-chat` to `deepseek-v4-flash` and disabled thinking for that request path.
  - Enabled minimal thinking for the Gemma config to match the intended runtime behavior.
- Runtime path handling
  - Updated config file lookups in `api_data.py`, `llm_manager.py`, `storage_manager.py`, and `tip_genius.py` to resolve from the package location instead of the current working directory.
  - Fixed the internal import in `llm_manager.py` to use the package-relative module path.
- Testing / tooling
  - Added `pytest` to dev dependencies and configured pytest discovery, marker registration, and default smoke-test exclusion.
  - Added a live smoke test that exercises every active LLM provider through `LLMManager.get_prediction()` when `RUN_SMOKE=1` is set.
