### PR TITLE
fix: remove unsupported `public` property from vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,5 @@
 {
-  "version": 2,
+  "$schema": "https://openapi.vercel.sh/vercel.json",
   "buildCommand": "npm install && npm run build",
-  "outputDirectory": "public",
-  "public": true
+  "outputDirectory": "public"
 }


### PR DESCRIPTION
## Problem

All Production and Preview deployments are failing with:

```
The `vercel.json` schema validation failed with the following message:
should NOT have additional property `public`
```

This fails at **schema validation**, before `npm install` even runs.

## This is not caused by the Dependabot merges

- `vercel.json` has not changed since **March 2025** (`b2b018b`) — no merged PR touched it.
- The first failure was **2026-06-23**; the last green deploy was **2026-06-09**. Both predate the merges of #43 and #46 (2026-08-16).
- All GitHub Actions (CodeQL, Dependabot) are green.
- A dependency version cannot produce a schema validation error.

Vercel removed `public` from the `vercel.json` schema on their side. The config sat unchanged and silently became invalid. The recent merges only *surfaced* it by triggering the first deployments in ~2 months — the scheduled predictions workflow kept passing, which masked the breakage.

## Fix

Per the [official Vercel docs](https://vercel.com/docs/project-configuration/vercel-json):

> **Note:** The `public` property is no longer supported and **will cause deployment failures**. Remove it from your `vercel.json` immediately to fix broken deployments.
>
> Deployments always keep source view and logs view protected behind authentication. The `public` property had no effect and is no longer accepted by the validator.

Since the property had no effect, **removing it changes no behaviour** — there is no loss of public source visibility to restore.

Additional changes in the same commit:

- **Dropped `"version": 2`** — documented under *Legacy* as "should not be used anymore". Not currently breaking, but the same once-harmless-then-fatal pattern.
- **Added `$schema`** — enables [autocomplete and validation in-editor](https://vercel.com/changelog/schema-autocomplete-and-validation-for-vercel-json), so a future removed property shows up as a red squiggle instead of a failed production deploy.

```diff
 {
-  "version": 2,
+  "$schema": "https://openapi.vercel.sh/vercel.json",
   "buildCommand": "npm install && npm run build",
-  "outputDirectory": "public",
-  "public": true
+  "outputDirectory": "public"
 }
```

Note `"outputDirectory": "public"` is a *different*, still-valid property and is retained.

## Verification

- `vercel build` passes locally with this config, including the merged `concurrently@10.0.3` and `python-dotenv@1.2.2`.
- The Preview deployment on this PR is the real check — it should go green.

## Suggested merge order

Merge this **first**, so the four open Dependabot PRs (#48–#51) get a clean deploy signal instead of inheriting a red one.