### PR TITLE
fix: repair malformed logging calls

### DIFF
--- a/src/tip_genius/lib/api_data.py
+++ b/src/tip_genius/lib/api_data.py
@@ -54,7 +54,7 @@ class BaseAPI(ABC):
             error_msg = f"Config file not found: {ODDS_CONFIG_FILE}"
             raise FileNotFoundError(error_msg) from exc
         except KeyError as exc:
-            logger.exception("Key not found in config: %s")
+            logger.exception("Key not found in config")
             error_msg = f"Key not found in config: {exc}"
             raise KeyError(error_msg) from exc
 

--- a/src/tip_genius/lib/storage_manager.py
+++ b/src/tip_genius/lib/storage_manager.py
@@ -99,7 +99,7 @@ class StorageManager:
             )
 
         except (FileNotFoundError, KeyError, yaml.YAMLError) as e:
-            logger.warning(("Vercel KV storage failed to initialize: %s", str(e)))
+            logger.warning("Vercel KV storage failed to initialize: %s", str(e))
 
         return False
 
@@ -264,7 +264,7 @@ class StorageManager:
                     key_name,
                 )
                 return True
-            logger.exception(
+            logger.error(
                 "Failed to write predictions in Vercel KV: HTTP %d, Response: %s",
                 response.status_code,
                 # Truncate the response text to avoid excessive logging
@@ -272,7 +272,7 @@ class StorageManager:
             )
 
         except Exception:
-            logger.exception("Failed to write predictions to KV: %s")
+            logger.exception("Failed to write predictions to KV")
             return False
 
         else:

--- a/src/tip_genius/tip_genius.py
+++ b/src/tip_genius/tip_genius.py
@@ -344,7 +344,7 @@ class TipGenius:
             logger.debug("LLM data stored in CSV: %s", csv_path)
 
         except Exception:
-            logger.exception("Failed to store LLM data: %s")
+            logger.exception("Failed to store LLM data")
             raise
 
     def store_api_data(
@@ -387,7 +387,7 @@ class TipGenius:
             logger.debug("API result stored successfully at: %s", file_path)
 
         except Exception:
-            logger.exception("A problem occurred while storing API result: %s")
+            logger.exception("A problem occurred while storing API result")
 
     def _wait_before_retry(
         self,
@@ -674,7 +674,7 @@ class TipGenius:
                         self.logo_matcher = TeamLogoMatcher(logo_directory=full_path)
                         logger.debug("TeamLogoMatcher successfully initialized.")
                     except Exception:
-                        logger.warning("Failed to initialize logo matcher: %s")
+                        logger.exception("Failed to initialize logo matcher")
                 else:
                     logger.warning(
                         "Not performing Logo matching, logo dir does not exist: %s",
@@ -826,12 +826,12 @@ class TipGenius:
                     export_success = self.export_results()
                     if not export_success and is_cloud_environment():
                         # Only exit with failure in cloud environments
-                        logger.exception(
+                        logger.error(
                             "Critical error during export. Exiting with status code 1.",
                         )
                         sys.exit(1)
                 except Exception:
-                    logger.exception("Failed to export results: %s")
+                    logger.exception("Failed to export results")
                     if is_cloud_environment():
                         sys.exit(1)
 
@@ -839,7 +839,7 @@ class TipGenius:
             self._log_workflow_summary()
 
         except Exception:
-            logger.exception("Critical workflow error: %s")
+            logger.exception("Critical workflow error")
             # Try to save any collected data even if workflow fails
             if self.prediction_data and (self.export_to_kv or self.export_to_file):
                 try:
@@ -847,7 +847,7 @@ class TipGenius:
                     if not export_success and is_cloud_environment():
                         sys.exit(1)
                 except Exception:
-                    logger.exception("Failed to export results after error: %s")
+                    logger.exception("Failed to export results after error")
                     if is_cloud_environment():
                         sys.exit(1)
             raise  # Re-raise the exception after attempting to save data


### PR DESCRIPTION
Noticed some odd log lines while testing locally and traced them to a few
malformed logging calls. Small PR, but figured it was worth sharing.

The clearest one is in `storage_manager.py` — when the KV env vars aren't set,
the warning is passed as a tuple instead of message + argument:

    before: WARNING ('Vercel KV storage failed to initialize: %s', "'KV_REST_API_TOKEN'")
    after:  WARNING Vercel KV storage failed to initialize: 'KV_REST_API_TOKEN'

Looks like it slipped in during 82dd9b8 — before that refactor the line was
`logger.error("Failed to initialize KV config: %s", str(e))`.

Three more of the same kind:

- Eight `logger.exception` calls have a `%s` with no argument, printing a
  literal `%s`. `logger.exception` already logs the traceback, so I dropped
  the placeholder.
- Two `logger.exception` calls sit outside an `except` block, adding a stray
  `NoneType: None` line. Changed to `logger.error`.
- The logo matcher handler used `logger.warning`, which prints no traceback —
  if `TeamLogoMatcher` fails you get no reason at all. Changed to
  `logger.exception`.

No behaviour change, only log output: I ran the KV path both ways with the env
vars unset and `kv_initialized` is `False` either way. `ruff check src/`,
`ruff format --check src/`, `pyright src/` and pre-commit pass.

Happy to split this up or drop any part.
